### PR TITLE
Enable threading for WASM build

### DIFF
--- a/WebServer.py
+++ b/WebServer.py
@@ -1,0 +1,16 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import sys
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    '''Custom HTTP request handler that adds CORS headers to enable SharedArrayBuffer'''
+    def end_headers (self):
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    port = int(sys.argv[1])
+
+    with HTTPServer(("", port), CORSRequestHandler) as httpd:
+        print("serving at port", port)
+        httpd.serve_forever()

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -28,7 +28,7 @@ RUN cmake --install .
 # Build Qt for WASM
 RUN mkdir -p /development/qt5_build
 WORKDIR /development/qt5_build
-RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -nomake examples -prefix /usr/local/Qt-wasm
+RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-thread -nomake examples -prefix /usr/local/Qt-wasm
 RUN cmake --build . --parallel 4
 RUN cmake --install .
 

--- a/run_webserver.bat
+++ b/run_webserver.bat
@@ -6,4 +6,4 @@ echo Opening web browser and starting web server...
 
 start http://localhost:80/helloworld.html
 
-python.exe -m http.server 80
+..\WebServer.py 80

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -3,6 +3,7 @@
 #include <QtPlugin>
 #include <string>
 #include <fstream>
+#include <thread>
 #include <iostream>
 
 
@@ -16,6 +17,10 @@ static void PrintFileContent (const char * filename) {
         std::cout << line << '\n';
 }
 
+void ThreadFunction () {
+    std::cout << "Hello thread\n";
+}
+
 int main(int argc, char *argv[])
 {
     PrintFileContent("example.txt");
@@ -25,6 +30,15 @@ int main(int argc, char *argv[])
 	} catch (std::exception & e) {
 		std::cout << "Exception catching works as expected: " << e.what() << std::endl;
 	}
+
+    try {
+        std::thread t(&ThreadFunction);
+        t.join();
+        std::cout << "Thread joined\n";
+    } catch (std::exception & e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+        return -1;
+    }
 
     QGuiApplication app(argc, argv);
 


### PR DESCRIPTION
Threading is already enabled by default for the x64 build, so there's no need for any changes there. The changes have been tested locally both with Qmake and Cmake.

Runtime error experienced if _not_ adding CORS headers:
```
ReferenceError: SharedArrayBuffer is not defined
    at eval (eval at completeLoadEmscriptenModule (qtloader.js:440:9), <anonymous>:9:12121)
    at completeLoadEmscriptenModule (qtloader.js:441:9)
    at qtloader.js:326:13
```