### PR TITLE
Increase stack size to 1MB

### DIFF
--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -15,6 +15,8 @@ add_compile_options(-fexceptions)
 add_compile_options(-pthread)
 add_link_options("SHELL:-s USE_PTHREADS=1")
 
+# Increase stack size (was reduced to 64k in Emscripten 3.1.27)
+add_link_options("SHELL:-sSTACK_SIZE=1MB")
 
 find_package(Qt6 REQUIRED Core QUIET)
 include(${QT6_INSTALL_PREFIX}/lib/cmake/Qt6/QtPublicWasmToolchainHelpers.cmake)


### PR DESCRIPTION
Fixes #20. The default stack size was decreased from 5MB to 64kB in Emscripten 3.1.27 (https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md). This appear to be too little for virtually any Qt applications.

Increasing to 1MB to match the default stack size on Windows. This should then probably also be sufficient for WASM builds.

It seems like according to [emcc.py](https://github.com/emscripten-core/emscripten/blob/main/emcc.py#L1659) that this change will also affect `DEFAULT_PTHREAD_STACK_SIZE`.