### PR TITLE
Upgrade default build to Qt 6.5 branch

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get -y install mesa-common-dev libgl1-mesa-dev libglu1
 
 # Clone Qt sources
 WORKDIR /development
-RUN git clone --branch=6.4 https://code.qt.io/qt/qt5.git
+RUN git clone --branch=6.5 https://code.qt.io/qt/qt5.git
 WORKDIR /development/qt5
 RUN git rev-parse HEAD
 RUN ./init-repository


### PR DESCRIPTION
Done to benefit from recent Qt WAM improvements, especially in the area of exception catching (se #15).