### PR TITLE
Stop limiting build parallelization

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -22,14 +22,14 @@ RUN ./init-repository
 RUN mkdir -p /development/qt5_build_x64
 WORKDIR /development/qt5_build_x64
 RUN /development/qt5/configure -nomake examples -nomake tests -prefix /usr/local/Qt-x64
-RUN cmake --build . --parallel 4
+RUN cmake --build .
 RUN cmake --install .
 
 # Build Qt for WASM
 RUN mkdir -p /development/qt5_build
 WORKDIR /development/qt5_build
 RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-thread -nomake examples -prefix /usr/local/Qt-wasm
-RUN cmake --build . --parallel 4
+RUN cmake --build .
 RUN cmake --install .
 
 


### PR DESCRIPTION
The former build failure in this area now seem to have been fixed. Probably related to the transition to ninja as back-end build engine.