### PR TITLE
Enable exceptions for WASM build

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -28,7 +28,7 @@ RUN cmake --install .
 # Build Qt for WASM
 RUN mkdir -p /development/qt5_build
 WORKDIR /development/qt5_build
-RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-thread -nomake examples -prefix /usr/local/Qt-wasm
+RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-wasm-exceptions -feature-thread -nomake examples -prefix /usr/local/Qt-wasm
 RUN cmake --build .
 RUN cmake --install .
 


### PR DESCRIPTION
Fixes #15. The `-feature-wasm-exceptions` flag was introduced in Qt 6.5: https://codereview.qt-project.org/c/qt/qtbase/+/449927