### PR TITLE
Using Qt tools and default flags

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -65,5 +65,5 @@ RUN mkdir -p /project/dependencies/include && mkdir -p /project/dependencies/lib
 # Build custom sources
 WORKDIR /project/build
 
-# Default build command
-CMD cmake -DCMAKE_TOOLCHAIN_FILE=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_PREFIX_PATH=/project/Qt /project/source && ninja
+# Default build command will explicitly target wasm
+CMD /usr/local/Qt-wasm/bin/qt-cmake -DCMAKE_BUILD_TYPE=Release -G Ninja /project/source && ninja

--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -10,13 +10,5 @@ list(APPEND CMAKE_FIND_ROOT_PATH "/")
 # https://emscripten.org/docs/optimizing/Optimizing-Code.html#c-exceptions
 add_compile_options(-fexceptions)
 
-# Enable threading also in non-Qt projects
-# https://emscripten.org/docs/porting/pthreads.html
-add_compile_options(-pthread)
-add_link_options("SHELL:-s USE_PTHREADS=1")
-
 # Increase stack size (was reduced to 64k in Emscripten 3.1.27)
 add_link_options("SHELL:-sSTACK_SIZE=1MB")
-
-find_package(Qt6 REQUIRED Core QUIET)
-include(${QT6_INSTALL_PREFIX}/lib/cmake/Qt6/QtPublicWasmToolchainHelpers.cmake)


### PR DESCRIPTION
Use Qt tools for cross-compiling.

Mainly the qt-cmake script just calls cmake with the correct qt/emscripten helper.
