### PR TITLE
Revert "Stop limiting build parallelization"

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -22,14 +22,14 @@ RUN ./init-repository
 RUN mkdir -p /development/qt5_build_x64
 WORKDIR /development/qt5_build_x64
 RUN /development/qt5/configure -nomake examples -nomake tests -prefix /usr/local/Qt-x64
-RUN cmake --build .
+RUN cmake --build . --parallel 4
 RUN cmake --install .
 
 # Build Qt for WASM
 RUN mkdir -p /development/qt5_build
 WORKDIR /development/qt5_build
 RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-wasm-exceptions -feature-thread -nomake examples -prefix /usr/local/Qt-wasm
-RUN cmake --build .
+RUN cmake --build . --parallel 4
 RUN cmake --install .
 
 


### PR DESCRIPTION
This reverts commit 3087c17a8d60d9244b02ccc875d9bd0e629f7808. Done to fix #31 which I suspect is due to some kind of "out of memory" problem.