### PR TITLE
Introduce EXTRA_BUILD_PARAMS argument for reducing build parallelization

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,9 @@
 # Based on https://github.com/emscripten-core/emsdk/tree/master/docker
 FROM emscripten/emsdk:3.1.27 AS qtbuilder
 
+# Extra Qt build parameters
+ARG EXTRA_BUILD_PARAMS=
+
 RUN mkdir -p /development
 
 # Install GE root certificate
@@ -22,14 +25,14 @@ RUN ./init-repository
 RUN mkdir -p /development/qt5_build_x64
 WORKDIR /development/qt5_build_x64
 RUN /development/qt5/configure -nomake examples -nomake tests -prefix /usr/local/Qt-x64
-RUN cmake --build .
+RUN cmake --build . $EXTRA_BUILD_PARAMS
 RUN cmake --install .
 
 # Build Qt for WASM
 RUN mkdir -p /development/qt5_build
 WORKDIR /development/qt5_build
 RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-wasm-exceptions -feature-thread -nomake examples -prefix /usr/local/Qt-wasm
-RUN cmake --build .
+RUN cmake --build . $EXTRA_BUILD_PARAMS
 RUN cmake --install .
 
 

--- a/image/build_image.bat
+++ b/image/build_image.bat
@@ -2,7 +2,7 @@
 ::set DOCKER_BUILDKIT=false
 
 :: Build container
-docker build --file Dockerfile --tag=forderud/qtwasm:latest .
+docker build --file Dockerfile --build-arg EXTRA_BUILD_PARAMS="--parallel 4" --tag=forderud/qtwasm:latest .
 
 IF %ERRORLEVEL% EQU 0 (
   :: Push to dockerhub


### PR DESCRIPTION
Leave the default blank to preserve existing behavior. Pass `EXTRA_BUILD_PARAMS="--parallel 4"` when building on Windows to fix #31.