### PR TITLE
Force UTF-8 locale

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -4,6 +4,9 @@ FROM emscripten/emsdk:3.1.27 AS qtbuilder
 # Extra Qt build parameters
 ARG EXTRA_BUILD_PARAMS=
 
+# Qt 6.5 show warnings if default locale is not UTF-8
+ENV LANG=C.UTF-8
+
 RUN mkdir -p /development
 
 # Install GE root certificate


### PR DESCRIPTION
We have warnings with latest builds which pops a bit anywhere:

![image](https://user-images.githubusercontent.com/1213231/221812414-359979ca-8b70-4e93-a538-dfc2a79d6e4e.png)

LANG is not set in the container, so the default locale is estimated to be "C".

It is possible to silence them by setting LANG=C.UTF-8.
