### PR TITLE
Light debug webserver

### DIFF
--- a/WebServer.py
+++ b/WebServer.py
@@ -1,12 +1,28 @@
 from http import server
 import sys
 
+match = {
+    '/source/': '../sample/'
+}
+
+
 class CORSRequestHandler (server.SimpleHTTPRequestHandler):
     '''Custom HTTP request handler that adds CORS headers to enable SharedArrayBuffer'''
     def end_headers (self):
         self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
         self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
         server.SimpleHTTPRequestHandler.end_headers(self)
+
+    def translate_path(self, path):
+        r = None
+        for tag in match:
+            if path.startswith(tag):
+                r = path.replace(tag, match[tag])
+                break
+        if r is None:
+            r =  server.SimpleHTTPRequestHandler.translate_path(self, path)
+        print(path, r)
+        return r
 
 if __name__ == '__main__':
     port = int(sys.argv[1])

--- a/build_cmake.bat
+++ b/build_cmake.bat
@@ -5,6 +5,6 @@ mkdir build
 
 :: Input sources must be found in "sample" subfolder
 :: Output binaries will be written to "build" subfolder
-docker run --rm -v %cd%\sample:/project/source -v %cd%\build:/project/build forderud/qtwasm:latest || exit /b 1
+docker run --rm -v %cd%\sample:/project/source -v %cd%\build:/project/build -e BUILD_TYPE forderud/qtwasm:latest || exit /b 1
 
 run_webserver.bat

--- a/build_cmake.sh
+++ b/build_cmake.sh
@@ -3,4 +3,6 @@
 rm -rf build
 mkdir build
 
-docker run --pull always -ti --rm -v `pwd`/sample:/project/source -v `pwd`/build:/project/build forderud/qtwasm:latest || exit 1
+docker run --pull always -ti --rm -v `pwd`/sample:/project/source -v `pwd`/build:/project/build -e BUILD_TYPE registry.qdel.fr/rholk/images:latest || exit 1
+
+./run_webserver.sh

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -72,4 +72,4 @@ RUN mkdir -p /project/dependencies/include && mkdir -p /project/dependencies/lib
 WORKDIR /project/build
 
 # Default build command will explicitly target wasm
-CMD /usr/local/Qt-wasm/bin/qt-cmake -DCMAKE_BUILD_TYPE=Release -G Ninja /project/source && ninja
+CMD /usr/local/Qt-wasm/bin/qt-cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-Release} -G Ninja /project/source && ninja

--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -8,3 +8,6 @@ list(APPEND CMAKE_FIND_ROOT_PATH "/")
 
 # Increase stack size (was reduced to 64k in Emscripten 3.1.27)
 add_link_options("SHELL:-sSTACK_SIZE=1MB")
+
+# If we are compiling in Debug or RelWithDebInfo, provide source map for webbrowser debugging
+add_link_options("$<$<CONFIG:DEBUG>:-gsource-map>" "$<$<CONFIG:RELWITHDEBINFO>:-gsource-map>")


### PR DESCRIPTION
Made in only one PR the 3 modifications:
- switch in sample app to use source map for debug builds
- modification on webserver.py file for serving files from source
- Added a capacity to switch the build mode easily when running scripts: (Release if not set)
 `$> BUILD_TYPE=RelWithDebInfo ./build_cmake.sh`
 `$> $env:BUILD_TYPE='Debug' ; .\build_cmake.bat`

I could separate the 3 commit, but they are all linked together.
(draft: testing on windows)