### PR TITLE
Update async QGuiApplication impl. doc

### DIFF
--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -56,13 +56,8 @@ int main(int argc, char *argv[])
 
 #ifdef Q_OS_WASM
     /*
-     * According to https://doc-snapshots.qt.io/qt6-dev/wasm.html#wasm-exceptions
-     * the call to QGuiApplication::exec is not compatible with emscripten
-     * when exceptions are enabled.
-     *
-     * Note that the runtime will not exit when leaving the main function on
-     * this platform.
-     * https://doc-snapshots.qt.io/qt6-dev/wasm.html#application-startup-and-the-event-loop
+     * Asynchronous main() implementation that omits exec() call as proposed in https://doc.qt.io/qt-6/wasm.html
+     * The QGuiApplication pointer leakage is therefore deliberate.
      */
     auto* g_app = new QGuiApplication(argc, argv);
     startEngine(g_app);


### PR DESCRIPTION
Changes:
* Shorten documentation to make it more concise.
* Update links from doc-snapshots to a long-term stable URL. This means that the "calling QApplication::exec() is not supported when exceptions are enabled" documentation is temporarily lost until Qt 6.5 is released. This point is fortunately not severe, since we still refer to the async programming pattern.
* Explicitly mention that the QGuiApplication pointer leakage is deliberate.