### PR TITLE
Extend sample project with Boost include

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -32,5 +32,9 @@ qt_import_qml_plugins(helloworld)
 find_package(Eigen3 REQUIRED NO_MODULE)
 target_link_libraries(helloworld PRIVATE Eigen3::Eigen)
 
+# Find Boost (for compatibility testing)'
+find_package(Boost REQUIRED)
+target_link_libraries(helloworld PRIVATE Boost::boost)
+
 configure_file(example.txt example.txt COPYONLY)
 target_link_libraries(helloworld PRIVATE "--preload-file example.txt")

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 #include <iostream>
 #include <Eigen/Dense>
+#include <boost/version.hpp>
 
 
 static void PrintFileContent (const char * filename) {
@@ -32,6 +33,7 @@ int main(int argc, char *argv[])
 {
     std::cout << "Qt version " << QT_VERSION_STR << std::endl;
 	std::cout << "Eigen version " << EIGEN_WORLD_VERSION << "." << EIGEN_MAJOR_VERSION  << "." << EIGEN_MINOR_VERSION << std::endl;
+	std::cout << "Boost version " << BOOST_VERSION << std::endl;
 	
 #ifdef NDEBUG
     std::cout << "Release build." << std::endl;

--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -5,6 +5,7 @@
 
 # Also search for packages beneath filesystem root (in addition to /emsdk_portable/sdk/system)
 list(APPEND CMAKE_FIND_ROOT_PATH "/")
+list(APPEND CMAKE_FIND_ROOT_PATH "/project/dependencies") # required for Boost
 
 # Increase stack size (was reduced to 64k in Emscripten 3.1.27)
 add_link_options("SHELL:-sSTACK_SIZE=1MB")


### PR DESCRIPTION
Done to verify that Boost can be found in the Docker image.


Chrome debug dialog output:
![image](https://user-images.githubusercontent.com/2671400/235722902-39036fd0-6087-4429-9e32-143a5a1b7a31.png)
