### PR TITLE
Switch to building v6.5.0 tag

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get -y install mesa-common-dev libgl1-mesa-dev libglu1
 
 # Clone Qt sources
 WORKDIR /development
-RUN git clone --branch=6.5 https://code.qt.io/qt/qt5.git
+RUN git clone --branch v6.5.0 https://code.qt.io/qt/qt5.git
 WORKDIR /development/qt5
 RUN git rev-parse HEAD
 RUN ./init-repository


### PR DESCRIPTION
Done to get more deterministic builds.

**Downside**: This will increase the maintenance burden, since the repo will need to be updated every time one wants to build against a more recent Qt version.