### PR TITLE
Add simd128 support

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -34,7 +34,7 @@ RUN cmake --install .
 # Build Qt for WASM
 RUN mkdir -p /development/qt5_build
 WORKDIR /development/qt5_build
-RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-wasm-exceptions -feature-thread -nomake examples -prefix /opt/Qt
+RUN /development/qt5/configure -qt-host-path /usr/local/Qt-x64 -xplatform wasm-emscripten -feature-wasm-simd128 -feature-wasm-exceptions -feature-thread -nomake examples -prefix /opt/Qt
 RUN cmake --build . $EXTRA_BUILD_PARAMS
 RUN cmake --install .
 


### PR DESCRIPTION
I have seen no issues when using this instruction set. Note that it comes with a couple of limitation in term of support: https://doc.qt.io/qt-6/wasm.html#simd

But it seems not to be an issue for all modern browsers (edge,chrome,firefox,safari) and modern platforms (windows 10/11, linux, android, ios...)

The flag -msimd128 will be propagated automatically if qt-cmake is used. We can compile non-msimd128 object with -msimd128-enabled objects.
