### PR TITLE
QMake: Switch to wasm-exceptions

### DIFF
--- a/sample/myproject.pro
+++ b/sample/myproject.pro
@@ -10,8 +10,7 @@ INCLUDEPATH  += /opt/wasm-deps/include
 INCLUDEPATH  += /opt/wasm-deps/include/eigen3
 
 # enable C++ exception catching
-QMAKE_CXXFLAGS += -fexceptions
-QMAKE_LFLAGS += -s DISABLE_EXCEPTION_CATCHING=0
+QMAKE_CXXFLAGS += -fwasm-exceptions
 
 # embed example.txt into binary
 QMAKE_PRE_LINK += $$QMAKE_COPY ../source/example.txt .


### PR DESCRIPTION
Done for consistency with the CMake project that have already switched to wasm-exceptions.