### PR TITLE
QMake: Increase stack size to 1MB

### DIFF
--- a/sample/myproject.pro
+++ b/sample/myproject.pro
@@ -13,6 +13,9 @@ INCLUDEPATH  += /opt/wasm-deps/include/eigen3
 QMAKE_CXXFLAGS += -fwasm-exceptions
 QMAKE_LFLAGS += -fwasm-exceptions
 
+# Increase stack size (was reduced to 64k in Emscripten 3.1.27)
+QMAKE_LFLAGS += -sSTACK_SIZE=1MB
+
 # embed example.txt into binary
 QMAKE_PRE_LINK += $$QMAKE_COPY ../source/example.txt .
 QMAKE_LFLAGS += --preload-file example.txt


### PR DESCRIPTION
Fixes #65 by making the configuration more similar to the corresponding CMake project.