### PR TITLE
Upgrade to Qt 6.6.1

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,5 +1,5 @@
 # Based on https://github.com/emscripten-core/emsdk/tree/master/docker
-FROM emscripten/emsdk:3.1.27 AS emscripten_base
+FROM emscripten/emsdk:3.1.37 AS emscripten_base
 
 FROM emscripten_base AS qtbuilder
 
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get -y install mesa-common-dev libgl1-mesa-dev libglu1
 
 # Clone Qt sources
 WORKDIR /development
-RUN git clone --branch v6.5.3 https://code.qt.io/qt/qt5.git
+RUN git clone --branch v6.6.1 https://code.qt.io/qt/qt5.git
 WORKDIR /development/qt5
 RUN git rev-parse HEAD
 RUN ./init-repository

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -42,4 +42,4 @@ find_package(HDF5 REQUIRED)
 target_link_libraries(helloworld PRIVATE hdf5::hdf5)
 
 configure_file(example.txt example.txt COPYONLY)
-target_link_libraries(helloworld PRIVATE "--preload-file example.txt")
+target_link_libraries(helloworld PRIVATE "--embed-file example.txt")

--- a/sample/myproject.pro
+++ b/sample/myproject.pro
@@ -18,4 +18,4 @@ QMAKE_LFLAGS += -sSTACK_SIZE=1MB
 
 # embed example.txt into binary
 QMAKE_PRE_LINK += $$QMAKE_COPY ../source/example.txt .
-QMAKE_LFLAGS += --preload-file example.txt
+QMAKE_LFLAGS += --embed-file example.txt


### PR DESCRIPTION
Combine with upgrading to Emscripten 3.1.37 as documented on https://doc.qt.io/qt-6/wasm.html#installing-emscripten

Observed a `Module.preRun.push is not a function` crash at startup after upgrading that was solved by switching from `--preload-file` to `--embed-file`. Not sure if this is the "best" way of fixing the problem though, but it seems to work for both the CMake and QMake builds.


## Preload problem detail (worked around)
This problem is _not_ tied to the Emscripten 3.1.37 upgrade. Upgrading to Qt 6.6.0 without also upgrading Emscripten also triggers the same problem.

The sample app crashed during startup with a `Module.preRun.push is not a function` error:
![image](https://github.com/forderud/QtWasm/assets/2671400/768a5345-39f5-46da-a84f-d2675067a30b)

The error is the same for both QMake and CMake builds.

Console output:
```
helloworld.html:66 TypeError: Module.preRun.push is not a function
    at loadPackage (helloworld.js:8:5562)
    at helloworld.js:8:5580
    at Object.entryFunction (helloworld.js:8:5678)
    at qtLoad (qtloader.js:211:40)
    at async init (helloworld.html:48:34)
init @ helloworld.html:66
helloworld.html:67 TypeError: Module.preRun.push is not a function
    at loadPackage (helloworld.js:8:5562)
    at helloworld.js:8:5580
    at Object.entryFunction (helloworld.js:8:5678)
    at qtLoad (qtloader.js:211:40)
    at async init (helloworld.html:48:34)
```

Extract of failing code in `helloworld.js`:
```
               ....
                if (Module["calledRun"]) {
                    runWithFS()
                } else {
                    if (!Module["preRun"])
                        Module["preRun"] = [];
                    Module["preRun"].push(runWithFS) <-- FAILURE POINT
                }
            };
            loadPackage({   <--- CALLING POINT
                "files": [{
                    "filename": "/example.txt",
                    "start": 0,
                    "end": 31
                }],
                "remote_package_size": 31
            })
```
The sources seem to come from Emscripten [file_packager.py](https://github.com/emscripten-core/emscripten/blob/3.1.37/tools/file_packager.py#L1079).