### PR TITLE
Enforce SSE2 requirement

### DIFF
--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -8,3 +8,9 @@ list(APPEND CMAKE_FIND_ROOT_PATH "/opt/wasm-deps") # required for Boost & Eigen
 
 # Increase stack size (was reduced to 64k in Emscripten 3.1.27)
 add_link_options("SHELL:-sSTACK_SIZE=1MB")
+
+# Adding sse2 support:
+# https://emscripten.org/docs/porting/simd.html#compiling-simd-code-targeting-x86-sse-instruction-sets
+# we do not need to add flag -msimd128 as it will be appended
+# by qt-cmake configuration
+add_compile_options(-msse2)


### PR DESCRIPTION
By default, emscripten does not enforce any SSE requirements.

gcc and msvc nowadays ensure SSE2 is used as default. Let's target the same level of optmization.

That would fix: https://github.com/forderud/QtWasm/issues/68
That needs this PR merged: https://github.com/forderud/QtWasm/pull/70
