### PR TITLE
Upgrade to Emscripten 3.1.50

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,5 +1,5 @@
 # Based on https://github.com/emscripten-core/emsdk/tree/master/docker
-FROM emscripten/emsdk:3.1.37 AS emscripten_base
+FROM emscripten/emsdk:3.1.50 AS emscripten_base
 
 FROM emscripten_base AS qtbuilder
 


### PR DESCRIPTION
Follow-up to the Qt 6.7 upgrade in #78 to stay in sync with the Emscripten version recommendations in https://doc-snapshots.qt.io/qt6-dev/wasm.html