### PR TITLE
Upgrade to building Qt 6.8 branch

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/emscripten-core/emsdk/tree/master/docker
 # The Emscripten version must match the Qt version as documented on https://doc.qt.io/qt-6/wasm.html and https://doc-snapshots.qt.io/qt6-dev/wasm.html
-FROM emscripten/emsdk:3.1.50 AS emscripten_base
+FROM emscripten/emsdk:3.1.56 AS emscripten_base
 
 FROM emscripten_base AS qtbuilder
 
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get -y install mesa-common-dev libgl1-mesa-dev libglu1
 
 # Clone Qt sources
 WORKDIR /development
-RUN git clone --branch 6.7 https://code.qt.io/qt/qt5.git
+RUN git clone --branch 6.8 https://code.qt.io/qt/qt5.git
 WORKDIR /development/qt5
 RUN git rev-parse HEAD
 RUN ./init-repository


### PR DESCRIPTION
Needed to also upgrade Emscripten to 3.1.56 to stay in sync with Qt as documented on https://doc.qt.io/qt-6/wasm.html

Screenshot:  
![image](https://github.com/user-attachments/assets/23ccfb4d-d647-4007-9ef3-95526941d627)
