### PR TITLE
Stop overriding stack size

### DIFF
--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -6,9 +6,6 @@
 # Also search for packages beneath filesystem root (in addition to /emsdk_portable/sdk/system)
 list(APPEND CMAKE_FIND_ROOT_PATH "/opt/wasm-deps") # required for Boost & Eigen
 
-# Increase stack size (was reduced to 64k in Emscripten 3.1.27)
-add_link_options("SHELL:-sSTACK_SIZE=1MB")
-
 # Adding sse2 support:
 # https://emscripten.org/docs/porting/simd.html#compiling-simd-code-targeting-x86-sse-instruction-sets
 # we do not need to add flag -msimd128 as it will be appended


### PR DESCRIPTION
Follow-up #21

This setting is no longer needed after https://codereview.qt-project.org/c/qt/qtbase/+/464454 was merged into the Qt "dev" branch 2023-03-03.

This means that WASM builds have had **5MB stack size by default since Qt 6.6**, which according to https://wiki.qt.io/Qt_6.6_Release was branched out on 2023-06-05.