### PR TITLE
Restore HDF5 build

### DIFF
--- a/image/0001-Only-clear-FE_INVALID-when-that-symbol-is-present-on.patch
+++ b/image/0001-Only-clear-FE_INVALID-when-that-symbol-is-present-on.patch
@@ -1,0 +1,43 @@
+From b9e918dec979668bdb337bc1daa5443776f5cd31 Mon Sep 17 00:00:00 2001
+From: Dana Robinson <43805+derobins@users.noreply.github.com>
+Date: Mon, 14 Oct 2024 14:30:22 -0700
+Subject: [PATCH] Only clear FE_INVALID when that symbol is present on the
+ system (#4954)
+
+When we initialize the floating-point types at library startup, it's
+possible to raise floating-point exceptions when we check which things
+are supported. Normally, we clear these floating-point exceptions via
+feclearexcept(FE_INVALID), but FE_INVALID may not be present on all
+systems. Specifically, this was reported as being a problem when using
+Emscripten 3.1.68 to compile HDF5 1.14.5 to WebAssembly.
+
+We've added an #ifdef FE_INVALID block around the exception clearing
+code to correct this.
+
+Fixes #4952
+---
+ src/H5Tinit_float.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/H5Tinit_float.c b/src/H5Tinit_float.c
+index 2642554b0f..6fc03c9c6c 100644
+--- a/src/H5Tinit_float.c
++++ b/src/H5Tinit_float.c
+@@ -608,9 +608,13 @@ H5T__init_native_float_types(void)
+ #endif
+ 
+ done:
+-    /* Clear any FE_INVALID exceptions from NaN handling */
++    /* Clear any FE_INVALID exceptions from NaN handling. FE_INVALID is C99/C11,
++     * but may not be present on all systems.
++     */
++#ifdef FE_INVALID
+     if (feclearexcept(FE_INVALID) != 0)
+         HSYS_GOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't clear floating-point exceptions");
++#endif
+ 
+     /* Restore the original environment */
+     if (feupdateenv(&saved_fenv) != 0)
+-- 
+2.45.0.windows.1
+

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -47,13 +47,11 @@ RUN cmake --install .
 # Build HDF5 for WASM
 COPY customtoolchainflags.cmake /
 WORKDIR /build
-# Download sources from official repo
-RUN wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz && \
-    tar -xf hdf5-1.14.6.tar.gz
-WORKDIR /build/hdf5-1.14.6
+RUN git clone --branch hdf5_1.14.6 https://github.com/HDFGroup/hdf5.git
+WORKDIR /build/hdf5
 
 # Apply custom patch(es)
-COPY *.patch /build/hdf5-1.14.6/
+COPY *.patch /build/hdf5/
 RUN git apply "0001-Only-clear-FE_INVALID-when-that-symbol-is-present-on.patch" # https://github.com/HDFGroup/hdf5/pull/4954
 
 #inject wasm specific flags in the projects
@@ -66,7 +64,7 @@ RUN emcmake cmake -S . -B build-wasm -DCMAKE_INSTALL_PREFIX:PATH=/opt/wasm-deps 
     -DHDF5_BUILD_CPP_LIB:BOOL=ON \
     -DHDF5_BUILD_EXAMPLES:BOOL=OFF \
     -DCMAKE_TOOLCHAIN_FILE=/customtoolchainflags.cmake
-WORKDIR /build/hdf5-1.14.6/build-wasm
+WORKDIR /build/hdf5/build-wasm
 RUN emmake make -j`nproc` install
 
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -62,8 +62,6 @@ RUN emcmake cmake -S . -B build-wasm -DCMAKE_INSTALL_PREFIX:PATH=/opt/wasm-deps 
     -DHDF5_BUILD_EXAMPLES:BOOL=OFF \
     -DCMAKE_TOOLCHAIN_FILE=/customtoolchainflags.cmake
 WORKDIR /build/hdf5-1.14.6/build-wasm
-# Redirect the output of the binary to a file (it should use the 1st argument... But it doesn't)
-RUN sed -i 's/js H5/js > H5/g' src/CMakeFiles/gen_hdf5-static.dir/build.make
 RUN emmake make -j`nproc` install
 
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -51,6 +51,11 @@ WORKDIR /build
 RUN wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz && \
     tar -xf hdf5-1.14.6.tar.gz
 WORKDIR /build/hdf5-1.14.6
+
+# Apply custom patch(es)
+COPY *.patch /build/hdf5-1.14.6/
+RUN git apply "0001-Only-clear-FE_INVALID-when-that-symbol-is-present-on.patch" # https://github.com/HDFGroup/hdf5/pull/4954
+
 #inject wasm specific flags in the projects
 RUN emcmake cmake -S . -B build-wasm -DCMAKE_INSTALL_PREFIX:PATH=/opt/wasm-deps \
     -DHDF5_INSTALL_CMAKE_DIR=lib/cmake/ \


### PR DESCRIPTION
Follow-up to #87 that restores the broken HDF5 build.

Changes:
* HDF5: Remove weird sed call that seem to be causing build failures.
* Cherry-pick HDFGroup/hdf5#4954 to revive WASM build
* Switch to building HDF5 from the git repo