### PR TITLE
Upgrade to Qt 6.10 branch

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/emscripten-core/emsdk/tree/master/docker (based on Ubuntu)
 # The Emscripten version must match the Qt version as documented on https://doc.qt.io/qt-6/wasm.html
-FROM emscripten/emsdk:3.1.70 AS emscripten_base
+FROM emscripten/emsdk:4.0.7 AS emscripten_base
 
 FROM emscripten_base AS qtbuilder
 
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get -y install mesa-common-dev libgl1-mesa-dev libglu1
 
 # Clone Qt sources
 WORKDIR /development
-RUN git clone --branch 6.9 https://code.qt.io/qt/qt5.git
+RUN git clone --branch 6.10 https://code.qt.io/qt/qt5.git
 WORKDIR /development/qt5
 RUN git rev-parse HEAD
 RUN ./init-repository


### PR DESCRIPTION
Probably makes sense now that Qt 6.10.0 is released.

DOC: https://wiki.qt.io/Qt_6.10_Release

Needed to combine with an Emscripten 4.0.7 upgrade to avoid the following error:
```
135.5 ERROR: You should use the recommended Emscripten version 4.0.7 with this Qt. You have 3.1.70.
135.5
135.5 CMake Error at qtbase/cmake/QtBuildInformation.cmake:240 (message):
135.5   Check the configuration messages for an error that has occurred.
135.5 Call Stack (most recent call first):
135.5   qtbase/cmake/QtBuildInformation.cmake:59 (qt_configure_print_summary)
135.5   qtbase/cmake/QtBaseTopLevelHelpers.cmake:114 (qt_print_feature_summary)
135.5   qtbase/cmake/QtBaseTopLevelHelpers.cmake:93 (qt_internal_print_top_level_info)
135.5   CMakeLists.txt:124 (qt_internal_top_level_end)
135.5
```