### PR TITLE
Add exception catching also in non-Qt libraries

### DIFF
--- a/sample/lib/lib.cpp
+++ b/sample/lib/lib.cpp
@@ -13,6 +13,12 @@ void CallLib() {
     printf("INCBIN file content: %.*s\n", gIncbinExampleSize, gIncbinExampleData);
 
     try {
+        throw std::runtime_error("Lib runtime_error");
+    } catch (const std::exception & e) {
+        printf("Exception catching works as expected: %s\n", e.what());
+    }
+
+    try {
         std::thread t(&ThreadFunction);
         t.join();
         printf("[thread joined]\n");

--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -6,6 +6,14 @@
 # Also search for packages beneath filesystem root (in addition to /emsdk_portable/sdk/system)
 list(APPEND CMAKE_FIND_ROOT_PATH "/opt/wasm-deps") # required for Boost & Eigen
 
+# Enable C++ exception catching also in non-Qt projects
+# https://emscripten.org/docs/porting/exceptions.html
+add_compile_options(-fwasm-exceptions) # enable WebAssembly exceptions
+
+# Enable threading also in non-Qt projects
+# https://emscripten.org/docs/porting/pthreads.html
+add_compile_options(-pthread)
+
 # Enable SSE2 support
 # https://emscripten.org/docs/porting/simd.html#compiling-simd-code-targeting-x86-sse-instruction-sets
 # Do not need to add "-msimd128" since it will be appended by qt-cmake


### PR DESCRIPTION
This required also introducing `-fwasm-exceptions` and `-pthread` to avoid a crash or linker error, since this library isn't Qt-based.

Build error if only defining `-fwasm-exceptions`:
`wasm-ld: error: --shared-memory is disallowed by lib.cpp.o because it was not compiled with 'atomics' or 'bulk-memory' features.`

Runtime error if only defining `-pthread`:
Runtime crash on throw.
