### PR TITLE
Automatically apply CMake toolchain with CMAKE_TOOLCHAIN_FILE

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -129,4 +129,4 @@ RUN mkdir -p /opt/wasm-deps/include && mkdir -p /opt/wasm-deps/lib && mkdir -p /
 WORKDIR /project/build
 
 # Default build command will explicitly target wasm
-CMD /opt/Qt/bin/qt-cmake -DCMAKE_BUILD_TYPE=Release -G Ninja /project/source && ninja
+CMD /opt/Qt/bin/qt-cmake -DCMAKE_TOOLCHAIN_FILE=/opt/wasm-deps/share/cmake/wasm.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja /project/source && ninja

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -3,9 +3,5 @@ set(CMAKE_CXX_STANDARD 17)
 
 project(sample)
 
-if(EMSCRIPTEN)
-  include(wasm.cmake)
-endif()
-
 add_subdirectory(lib)
 add_subdirectory(app)

--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -1,4 +1,8 @@
 # Configure WebAssembly build settings
+
+# Use Emscripten build settings as starting point
+include($ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake)
+
 # For some reason, the build settings need to be provided through the linker.
 # Most flags are configured to match Qt qmake
 # See EMCC_COMMON_LFLAGS in https://github.com/qt/qtbase/blob/dev/mkspecs/common/wasm/wasm.conf


### PR DESCRIPTION
Follow-up to #97. Update the Docker image to automatically apply the CMake toolchain when building CMake projects.

#### Benefit
* Avoid having to hardcode the CMake toolchain path in client projects.

#### Downside
* More difficult to test toolchain modifications.


## To investigate
* Switch from `CMAKE_TOOLCHAIN_FILE` to `QT_CHAINLOAD_TOOLCHAIN_FILE`
* Switch from `qt-cmake` to regular `cmake`

## Error when testing the image
```
D:\Dev\QtWasm>build_cmake.bat
...
D:\Dev\QtWasm>docker run --rm -v D:\Dev\QtWasm\sample:/project/source -v D:\Dev\QtWasm\build:/project/build forderud/qtwasm:latest   || exit /b 1
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - broken
CMake Error at /usr/share/cmake-3.22/Modules/CMakeTestCCompiler.cmake:69 (message):
  The C compiler

    "/usr/bin/cc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /project/build/CMakeFiles/CMakeTmp

    Run Build Command(s):/usr/bin/ninja cmTC_c400f && [1/2] Building C object CMakeFiles/cmTC_c400f.dir/testCCompiler.c.o
    FAILED: CMakeFiles/cmTC_c400f.dir/testCCompiler.c.o
    /usr/bin/cc   -fwasm-exceptions -pthread -msse2 -o CMakeFiles/cmTC_c400f.dir/testCCompiler.c.o -c /project/build/CMakeFiles/CMakeTmp/testCCompiler.c
    cc: error: unrecognized command-line option '-fwasm-exceptions'; did you mean '--warn-exceptions'?
    ninja: build stopped: subcommand failed.
```
