### PR TITLE
Enable debugging on windows

### DIFF
--- a/build_cmake.bat
+++ b/build_cmake.bat
@@ -23,4 +23,16 @@ if "%BUILD_TYPE%"=="" (
   docker run --rm %MOUNT_SOURCE% %MOUNT_BUILD% %DOCKER_IMAGE% /bin/bash -c "/opt/Qt/bin/qt-cmake -DQT_CHAINLOAD_TOOLCHAIN_FILE=/project/source/wasm.cmake -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -G Ninja /project/source && ninja" || exit /b 1
 )
 
-run_webserver.bat
+:: Serve the webpage from current folder (%cd% ==> within docker that is /project)
+:: To reflect what was built, we need /project/source and /project/build available
+:: Correct file-mapping will make it possible to attach a debugger later 
+set LOCAL_DEPLOY_FOLDER=%cd%
+set DOCKER_DEPLOY_FOLDER=/project
+
+start http://localhost:8080/build/app/helloworld.html
+
+docker run --rm -p 8080:8080 ^
+    -v %LOCAL_DEPLOY_FOLDER%:%DOCKER_DEPLOY_FOLDER% ^
+    %MOUNT_SOURCE% ^
+    -w %DOCKER_DEPLOY_FOLDER% %DOCKER_IMAGE% ^
+    python3 WebServer.py 8080

--- a/image/wasm.cmake
+++ b/image/wasm.cmake
@@ -20,3 +20,9 @@ add_compile_options(-pthread)
 # Enable SSE2 support
 # https://emscripten.org/docs/porting/simd.html
 add_compile_options(-msse2 -mrelaxed-simd)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    # Generate debug information to enable in-browser debugging
+    # https://emscripten.org/docs/porting/Debugging.html
+    add_link_options("SHELL:-gsource-map")
+endif()


### PR DESCRIPTION
Enable debugging through generating source map and serving the web-page through the same docker image which was used to generate the build. This is necessary to get the source-mapping right

This is an alternative https://github.com/forderud/QtWasm/pull/103 but here we avoid copying files, and it is a bit more clear why it works (we are mapping to the same folders as was used when the .map-file was created)

https://github.com/forderud/QtWasm/pull/36/ has previously tried to do something similar, but I think it is better to do it this way.

It has been a bit confusing when I get source code or not, but after I did this "disable cache", results have been reproducible (when it works or not) 
<img width="929" height="123" alt="image" src="https://github.com/user-attachments/assets/bb5eea0e-e5e4-4db6-8f6c-6a960bfee44f" />



