### PR TITLE
Automatically apply CMake toolchain with QT_CHAINLOAD_TOOLCHAIN_FILE

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -129,4 +129,4 @@ RUN mkdir -p /opt/wasm-deps/include && mkdir -p /opt/wasm-deps/lib && mkdir -p /
 WORKDIR /project/build
 
 # Default build command will explicitly target wasm
-CMD /opt/Qt/bin/qt-cmake -DCMAKE_BUILD_TYPE=Release -G Ninja /project/source && ninja
+CMD /opt/Qt/bin/qt-cmake -DQT_CHAINLOAD_TOOLCHAIN_FILE=/opt/wasm-deps/share/cmake/wasm.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja /project/source && ninja

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -3,9 +3,5 @@ set(CMAKE_CXX_STANDARD 17)
 
 project(sample)
 
-if(EMSCRIPTEN)
-  include(wasm.cmake)
-endif()
-
 add_subdirectory(lib)
 add_subdirectory(app)

--- a/sample/wasm.cmake
+++ b/sample/wasm.cmake
@@ -3,6 +3,9 @@
 # Most flags are configured to match Qt qmake
 # See EMCC_COMMON_LFLAGS in https://github.com/qt/qtbase/blob/dev/mkspecs/common/wasm/wasm.conf
 
+# Use Emscripten toolchain as starting point
+include($ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake)
+
 # Also search for packages beneath /opt/wasm-deps in addition to /emsdk_portable/sdk/system
 list(APPEND CMAKE_FIND_ROOT_PATH "/opt/wasm-deps") # required for Boost & Eigen
 


### PR DESCRIPTION
Alternative to #98 that I managed to get to work after adding a `Emscripten.cmake` include in `wasm.cmake`.

#### Benefit
* Avoid having to hardcode the CMake toolchain path in client projects.

#### Downside
* A bit more cumbersome to test toolchain modifications (see #101).
