### PR TITLE
Document how to override CMake build settings

### DIFF
--- a/build_cmake.bat
+++ b/build_cmake.bat
@@ -5,6 +5,11 @@ mkdir build
 
 :: Input sources must be found in "sample" subfolder
 :: Output binaries will be written to "build" subfolder
+
+:: Default build settings
 docker run --rm -v %cd%\sample:/project/source -v %cd%\build:/project/build forderud/qtwasm:latest || exit /b 1
+
+:: Custom build settings
+::docker run --rm -v %cd%\sample:/project/source -v %cd%\build:/project/build forderud/qtwasm:latest /bin/bash -c "/opt/Qt/bin/qt-cmake -DQT_CHAINLOAD_TOOLCHAIN_FILE=/project/source/wasm.cmake -DCMAKE_BUILD_TYPE=Release -G Ninja /project/source && ninja" || exit /b 1
 
 run_webserver.bat


### PR DESCRIPTION
This pattern will soon be used to test of wasm.cmake changes without having to first create a new docker image.

**Disclaimer**: Doesn't work before `include($ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake)` is added to wasm.cmake. This will soon be done in a separate PR.
