### PR TITLE
Generate debug information in Debug & RelWithDebInfo builds (with source copying)

### DIFF
--- a/image/wasm.cmake
+++ b/image/wasm.cmake
@@ -20,3 +20,13 @@ add_compile_options(-pthread)
 # Enable SSE2 support
 # https://emscripten.org/docs/porting/simd.html
 add_compile_options(-msse2 -mrelaxed-simd)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    # Generate debug information to enable in-browser debugging
+    # https://emscripten.org/docs/porting/Debugging.html
+    add_link_options("SHELL:-gsource-map")
+
+    # Copy sources to binary dir, so that they become available to the debugger
+    # WARNING: This will expose sourcecode togther with the WASM binaries
+    file(COPY ${CMAKE_SOURCE_DIR} DESTINATION ${CMAKE_BINARY_DIR})
+endif()


### PR DESCRIPTION
Fixes #75 by enabling in-browser debugging.

**WARNING**: This will also copy the sources to the WASM binary folder to make them available to the web browser. This can easily lead to source-code loss if publishing `Debug` or `RelWithDebInfo` builds without first deleting the source files.

## Build artifact impact
* A new 260kB `helloworld.wasm.map` file is generated alongside the existing `helloworld.wasm`
* `Debug` build artifacts grow from 36.7MB to 37.0MB


## Testing instructions
* Modify `build_cmake.bat` to apply the `wasm.cmake` changes and trigger a `Debug` build:
```
copy image\wasm.cmake sample
docker run --rm -v %cd%\sample:/project/source -v %cd%\build:/project/build forderud/qtwasm:latest /bin/bash -c "/opt/Qt/bin/qt-cmake -DQT_CHAINLOAD_TOOLCHAIN_FILE=/project/source/wasm.cmake -DCMAKE_BUILD_TYPE=Debug -G Ninja /project/source && ninja" || exit /b 1
```
* Run `build_cmake.bat` and wait for the app to open in a web browser
* Press F12 to open Chrome DevTools
* Place breakpoints & step through the code

<img width="945" height="719" alt="image" src="https://github.com/user-attachments/assets/9b8493cd-b1bc-45cb-92f7-41ce3c81aa11" />


## Other flags tested
I've also tested adding `add_link_options("SHELL:-gseparate-dwarf")`. This flag led to creation of a new 35.2MB `helloworld.wasm.debug.wasm` file, while the existing `helloworld.wasm` file shrank from 35.2MB to 31.5MB (3.7MB smaller). This >30MB increase in artifact size with no apparent benefits didn't feel very attractive to me.