### PR TITLE
Generate debug information in Debug & RelWithDebInfo builds

### DIFF
--- a/image/wasm.cmake
+++ b/image/wasm.cmake
@@ -20,3 +20,9 @@ add_compile_options(-pthread)
 # Enable SSE2 support
 # https://emscripten.org/docs/porting/simd.html
 add_compile_options(-msse2 -mrelaxed-simd)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    # Generate debug information to enable in-browser debugging
+    # https://emscripten.org/docs/porting/Debugging.html
+    add_link_options("SHELL:-gsource-map")
+endif()


### PR DESCRIPTION
This generates a source map when building in Debug or RelWithDebInfo

This is a pre-requisite to be able to debug the code with F12 in web browser. The source mapping does not match what is on disk due to directories being different in the docker container.  In a followup-PR I have suggested how to deal with that https://github.com/forderud/QtWasm/pull/99

To test this, please use build_cmake.bat with arguments "Debug" or "RelWithDebInfo" to get debugging working and copy it's source from https://github.com/forderud/QtWasm/pull/99 

I suggest to do this PR as a first step, then generate a new image to get wasm.cmake as part of the image and then do small tweaks to https://github.com/forderud/QtWasm/pull/99 as needed.