### PR TITLE
Generate debug information in Debug & RelWithDebInfo builds (without copying)

### DIFF
--- a/build_cmake.bat
+++ b/build_cmake.bat
@@ -17,6 +17,8 @@ set MOUNT_BUILD=-v %cd%\build:/project/build
 if "%BUILD_TYPE%"=="" (
   :: Default build settings
   docker run --rm %MOUNT_SOURCE% %MOUNT_BUILD% %DOCKER_IMAGE% || exit /b 1
+  :: Don't expose sources through webserver
+  set MOUNT_SOURCE=
 ) else (
   :: Custom build settings
   copy image\wasm.cmake sample
@@ -30,6 +32,6 @@ start http://localhost:8080/build/app/helloworld.html
 :: so that file paths match build-time paths.
 docker run --rm -p 8080:8080 ^
     -v %cd%\WebServer.py:/project/WebServer.py ^
-    %MOUNT_BUILD% ^
+    %MOUNT_SOURCE% %MOUNT_BUILD% ^
     -w /project %DOCKER_IMAGE% ^
     python3 WebServer.py 8080

--- a/image/wasm.cmake
+++ b/image/wasm.cmake
@@ -20,3 +20,9 @@ add_compile_options(-pthread)
 # Enable SSE2 support
 # https://emscripten.org/docs/porting/simd.html
 add_compile_options(-msse2 -mrelaxed-simd)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    # Generate debug information to enable in-browser debugging
+    # https://emscripten.org/docs/porting/Debugging.html
+    add_link_options("SHELL:-gsource-map")
+endif()


### PR DESCRIPTION
Fixes #75 by enabling in-browser debugging. Based on #99 with modifications to only expose sources for non-default builds.

**WARNING**: This will also expose the sources from the web server to make them available to the web browser. This can easily lead to source-code loss if publishing Debug or RelWithDebInfo builds if using the inbuilt web server.

## Build artifact impact
* A new 260kB `helloworld.wasm.map` file is generated alongside the existing `helloworld.wasm`
* `Debug` build artifacts grow from 36.7MB to 37.0MB


## Testing instructions
* Run `build_cmake.bat Debug` to trigger a `Debug` build
* Wait for the app to open in a web browser
* Press F12 to open Chrome DevTools
* Place breakpoints & step through the code

<img width="945" height="719" alt="image" src="https://github.com/user-attachments/assets/9b8493cd-b1bc-45cb-92f7-41ce3c81aa11" />


## Other flags tested
I've also tested adding `add_link_options("SHELL:-gseparate-dwarf")`. This flag led to creation of a new 35.2MB `helloworld.wasm.debug.wasm` file, while the existing `helloworld.wasm` file shrank from 35.2MB to 31.5MB (3.7MB smaller). This >30MB increase in artifact size with no apparent benefits didn't feel very attractive to me.
